### PR TITLE
Implement Admin Dashboard

### DIFF
--- a/back-end/prisma/migrations/20260118231755_add_role_enum/migration.sql
+++ b/back-end/prisma/migrations/20260118231755_add_role_enum/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - The `role` column on the `User` table would be dropped and recreated. This will lead to data loss if there is data in the column.
+
+*/
+-- CreateEnum
+CREATE TYPE "Role" AS ENUM ('USER', 'MODERATOR', 'ADMIN');
+
+-- AlterTable
+ALTER TABLE "User" DROP COLUMN "role",
+ADD COLUMN     "role" "Role" NOT NULL DEFAULT 'USER';

--- a/back-end/prisma/schema.prisma
+++ b/back-end/prisma/schema.prisma
@@ -37,7 +37,7 @@ model User {
   isPrivate   Boolean @default(false)
   isActive    Boolean @default(true)
   isSuspended Boolean @default(false)
-  role        String  @default("user") // 'user' | 'moderator' | 'admin'
+  role        Role    @default(USER)
 
   // Location (optional)
   locationName      String?
@@ -90,6 +90,12 @@ model User {
   @@index([username])
   @@index([email])
   @@index([createdAt])
+}
+
+enum Role {
+  USER
+  MODERATOR
+  ADMIN
 }
 
 model Post {

--- a/back-end/src/auth/auth.controller.ts
+++ b/back-end/src/auth/auth.controller.ts
@@ -24,13 +24,29 @@ export class AuthController {
 		@Res({ passthrough: true }) res: Response,
 	): Promise<string> {
 		try {
+			// Only allow setting a non-default role when a valid ADMIN_TOKEN is provided
+			const { role, adminToken, password, ...rest } = data as any;
+
 			const userData: AuthUserRegistration = {
 				displayName:
 					data.displayName === undefined
 						? data.username
 						: data.displayName,
-				...data,
+				username: data.username,
+				email: data.email,
+				password: password,
 			};
+
+			if (role) {
+				const envToken = process.env.ADMIN_TOKEN;
+				if (!envToken || !adminToken || adminToken !== envToken) {
+					res.status(HttpStatus.FORBIDDEN);
+					return JSON.stringify({ error: 'Invalid admin token' });
+				}
+				// role is validated by DTO; map to expected lowercase before service
+				userData.role = role;
+			}
+
 			await this.authService.createUser(userData);
 			res.status(HttpStatus.CREATED);
 			return JSON.stringify({ message: 'Registered successfully' });

--- a/back-end/src/auth/auth.dto.ts
+++ b/back-end/src/auth/auth.dto.ts
@@ -4,6 +4,7 @@ import {
 	MinLength,
 	MaxLength,
 	IsOptional,
+	IsIn,
 } from 'class-validator';
 
 export class RegisterDto {
@@ -68,6 +69,16 @@ export class CreateUserDto {
 	@MaxLength(100)
 	@IsOptional()
 	displayName?: string;
+
+	// Optional role and admin token — role can only be applied when adminToken matches server ENV
+	@IsString()
+	@IsOptional()
+	@IsIn(['user', 'moderator', 'admin'])
+	role?: string;
+
+	@IsString()
+	@IsOptional()
+	adminToken?: string;
 }
 
 export class RefreshTokenDto {

--- a/back-end/src/auth/auth.service.ts
+++ b/back-end/src/auth/auth.service.ts
@@ -17,14 +17,20 @@ export class AuthService {
 	async createUser(data: AuthUserRegistration): Promise<User> {
 		const salt = await bcrypt.genSalt();
 		const hash = await bcrypt.hash(data.password, salt);
-		return this.prisma.user.create({
-			data: {
-				email: data.email,
-				username: data.username,
-				passwordHash: hash,
-				displayName: data.displayName,
-			},
-		});
+		const createData: any = {
+			email: data.email,
+			username: data.username,
+			passwordHash: hash,
+			displayName: data.displayName,
+		};
+
+		// allow role to be set when provided (used for seeding/admin creation)
+		if (data.role) {
+			// Prisma enum values are uppercased in schema: USER, MODERATOR, ADMIN
+			createData.role = data.role.toUpperCase();
+		}
+
+		return this.prisma.user.create({ data: createData });
 	}
 
 	async LoginUser(

--- a/back-end/src/auth/auth.type.ts
+++ b/back-end/src/auth/auth.type.ts
@@ -3,4 +3,5 @@ export interface AuthUserRegistration {
 	password: string;
 	email: string;
 	displayName: string;
+	role?: 'user' | 'moderator' | 'admin';
 }

--- a/front-end/app/admin/page.tsx
+++ b/front-end/app/admin/page.tsx
@@ -1,0 +1,83 @@
+
+'use client';
+
+import React, { useState } from 'react';
+import { WithSidebar } from '@/components/ContentWithSidebar';
+import UsersPanel from '@/components/AdminPanels/UsersPanel';
+import PostsPanel from '@/components/AdminPanels/PostsPanel';
+import ReportsPanel from '@/components/AdminPanels/ReportsPanel';
+import NotificationsPanel from '@/components/AdminPanels/NotificationsPanel';
+
+export default function AdminPage() {
+	const [panel, setPanel] = useState<string | null>(null);
+	return (
+		<WithSidebar>
+			<div className="max-w-4xl mx-auto py-8 px-4">
+				<header className="mb-6">
+					<h1 className="text-2xl font-bold">Admin Dashboard</h1>
+					<p className="text-sm text-gray-600">Overview and quick actions for administrators</p>
+				</header>
+
+				<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+					<Card title="Users" subtitle="Manage users, roles and activity">
+						<button onClick={() => setPanel('users')} className="mt-3 px-3 py-2 bg-blue-500 text-white rounded">View users</button>
+					</Card>
+
+					<Card title="Posts" subtitle="Review or remove problematic posts">
+						<button onClick={() => setPanel('posts')} className="mt-3 px-3 py-2 bg-blue-500 text-white rounded">View posts</button>
+					</Card>
+
+					<Card title="Reports" subtitle="See user reports and handle them">
+						<button onClick={() => setPanel('reports')} className="mt-3 px-3 py-2 bg-blue-500 text-white rounded">View reports</button>
+					</Card>
+
+					<Card title="Notifications" subtitle="Broadcast system notifications">
+						<button onClick={() => setPanel('notifications')} className="mt-3 px-3 py-2 bg-blue-500 text-white rounded">Send notification</button>
+					</Card>
+				</div>
+
+				{panel === 'users' && (
+					<div className="mt-6">
+						<UsersPanel />
+					</div>
+				)}
+				{panel === 'posts' && (
+					<div className="mt-6">
+						<PostsPanel />
+					</div>
+				)}
+				{panel === 'reports' && (
+					<div className="mt-6">
+						<ReportsPanel />
+					</div>
+				)}
+				{panel === 'notifications' && (
+					<div className="mt-6">
+						<NotificationsPanel />
+					</div>
+				)}
+
+				<section className="mt-8">
+					<h2 className="text-lg font-semibold mb-3">Recent activity</h2>
+					<div className="space-y-3">
+						<div className="p-3 bg-white dark:bg-gray-800 rounded border border-gray-200 dark:border-gray-700">No recent activity</div>
+					</div>
+				</section>
+			</div>
+		</WithSidebar>
+	);
+}
+
+function Card({ title, subtitle, children }: { title: string; subtitle: string; children?: React.ReactNode }) {
+	return (
+		<div className="p-4 bg-white dark:bg-gray-800 rounded-xl border border-gray-200 dark:border-gray-700 shadow-sm">
+			<div className="flex items-center justify-between">
+				<div>
+					<p className="font-semibold text-lg">{title}</p>
+					<p className="text-sm text-gray-500">{subtitle}</p>
+				</div>
+			</div>
+			{children}
+		</div>
+	);
+}

--- a/front-end/app/api/admin/notifications/route.ts
+++ b/front-end/app/api/admin/notifications/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server';
+
+const MOCK_NOTIFS = [
+  { id: 'n1', title: 'Maintenance', message: 'System maintenance tonight' },
+];
+
+export async function GET() {
+  return NextResponse.json(MOCK_NOTIFS);
+}

--- a/front-end/app/api/admin/posts/[id]/route.ts
+++ b/front-end/app/api/admin/posts/[id]/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from 'next/server';
+
+export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
+  return NextResponse.json({ ok: true, id: params.id });
+}

--- a/front-end/app/api/admin/posts/route.ts
+++ b/front-end/app/api/admin/posts/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const MOCK_POSTS = [
+  { id: 101, body: 'First post', author: 'alice' },
+  { id: 102, body: 'Second post', author: 'bob' },
+];
+
+export async function GET() {
+  return NextResponse.json(MOCK_POSTS);
+}

--- a/front-end/app/api/admin/reports/route.ts
+++ b/front-end/app/api/admin/reports/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+const MOCK_REPORTS = [
+  { id: 'r1', type: 'post', targetId: '101', reason: 'spam' },
+  { id: 'r2', type: 'comment', targetId: '201', reason: 'abuse' },
+];
+
+export async function GET() {
+  return NextResponse.json(MOCK_REPORTS);
+}

--- a/front-end/app/api/admin/users/[id]/route.ts
+++ b/front-end/app/api/admin/users/[id]/route.ts
@@ -1,0 +1,6 @@
+import { NextResponse } from 'next/server';
+
+export async function DELETE(_request: Request, { params }: { params: { id: string } }) {
+  // fake delete - always returns success
+  return NextResponse.json({ ok: true, id: params.id });
+}

--- a/front-end/app/api/admin/users/route.ts
+++ b/front-end/app/api/admin/users/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+const MOCK_USERS = [
+  { id: 'u1', username: 'alice', email: 'alice@example.com', role: 'USER' },
+  { id: 'u2', username: 'bob', email: 'bob@example.com', role: 'MODERATOR' },
+  { id: 'u3', username: 'charlie', email: 'charlie@example.com', role: 'USER' },
+];
+
+export async function GET() {
+  return NextResponse.json(MOCK_USERS);
+}

--- a/front-end/components/AdminDeleteButton.tsx
+++ b/front-end/components/AdminDeleteButton.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import React from 'react';
+
+export default function AdminDeleteButton({ type, id }: { type: 'post' | 'comment'; id: number }) {
+  const isAdmin = typeof window !== 'undefined' && window.localStorage.getItem('isAdmin') === 'true';
+  if (!isAdmin) return null;
+
+  async function handleDelete() {
+    if (!confirm(`Delete ${type}?`)) return;
+    try {
+      const res = await fetch(`/api/admin/${type}s/${id}`, { method: 'DELETE' });
+      if (!res.ok) throw new Error('Delete failed');
+      alert(`${type} deleted (fake)`);
+    } catch (e) {
+      console.error(e);
+      alert('Failed to delete');
+    }
+  }
+
+  return (
+    <button onClick={handleDelete} className="text-xs text-red-600 hover:underline">
+      Delete
+    </button>
+  );
+}

--- a/front-end/components/AdminOnly.tsx
+++ b/front-end/components/AdminOnly.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+export default function AdminOnly({ children }: { children: React.ReactNode }) {
+  // naive admin check: read localStorage flag set by dev
+  const isAdmin = typeof window !== 'undefined' && window.localStorage.getItem('isAdmin') === 'true';
+  if (!isAdmin) return null;
+  return <>{children}</>;
+}

--- a/front-end/components/AdminPanels/NotificationsPanel.tsx
+++ b/front-end/components/AdminPanels/NotificationsPanel.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+
+export default function NotificationsPanel() {
+  const [notifs, setNotifs] = useState<any[]>([]);
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/admin/notifications');
+      const data = await res.json();
+      setNotifs(data);
+    })();
+  }, []);
+
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">Notifications</h3>
+      <div className="space-y-2">
+        {notifs.map(n => (
+          <div key={n.id} className="p-2 bg-white dark:bg-gray-800 rounded">
+            <div className="font-medium">{n.title}</div>
+            <div className="text-sm text-gray-500">{n.message}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front-end/components/AdminPanels/PostsPanel.tsx
+++ b/front-end/components/AdminPanels/PostsPanel.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+
+export default function PostsPanel() {
+  const [posts, setPosts] = useState<any[]>([]);
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/admin/posts');
+      const data = await res.json();
+      setPosts(data);
+    })();
+  }, []);
+
+  async function handleDelete(id: number) {
+    if (!confirm('Delete post?')) return;
+    const res = await fetch(`/api/admin/posts/${id}`, { method: 'DELETE' });
+    if (res.ok) setPosts(p => p.filter(x => x.id !== id));
+  }
+
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">Posts</h3>
+      <div className="space-y-2">
+        {posts.map(p => (
+          <div key={p.id} className="p-2 bg-white dark:bg-gray-800 rounded flex items-center justify-between">
+            <div>{p.body}</div>
+            <div><button onClick={() => handleDelete(p.id)} className="text-red-600 text-sm">Delete</button></div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front-end/components/AdminPanels/ReportsPanel.tsx
+++ b/front-end/components/AdminPanels/ReportsPanel.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+
+export default function ReportsPanel() {
+  const [reports, setReports] = useState<any[]>([]);
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/admin/reports');
+      const data = await res.json();
+      setReports(data);
+    })();
+  }, []);
+
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">Reports</h3>
+      <div className="space-y-2">
+        {reports.map(r => (
+          <div key={r.id} className="p-2 bg-white dark:bg-gray-800 rounded">
+            <div className="font-medium">{r.type} #{r.targetId}</div>
+            <div className="text-sm text-gray-500">Reason: {r.reason}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front-end/components/AdminPanels/UsersPanel.tsx
+++ b/front-end/components/AdminPanels/UsersPanel.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+
+export default function UsersPanel() {
+  const [users, setUsers] = useState<any[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      const res = await fetch('/api/admin/users');
+      const data = await res.json();
+      setUsers(data);
+    })();
+  }, []);
+
+  async function handleDelete(id: string) {
+    if (!confirm('Delete user?')) return;
+    const res = await fetch(`/api/admin/users/${id}`, { method: 'DELETE' });
+    if (res.ok) setUsers(u => u.filter(x => x.id !== id));
+  }
+
+  return (
+    <div>
+      <h3 className="font-semibold mb-2">Users</h3>
+      <div className="space-y-2">
+        {users.map(u => (
+          <div key={u.id} className="p-2 bg-white dark:bg-gray-800 rounded flex items-center justify-between">
+            <div>
+              <div className="font-medium">{u.username} <span className="text-xs text-gray-500">{u.email}</span></div>
+              <div className="text-xs text-gray-400">Role: {u.role}</div>
+            </div>
+            <div>
+              <button onClick={() => handleDelete(u.id)} className="text-red-600 text-sm">Delete</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/front-end/components/Comment.tsx
+++ b/front-end/components/Comment.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import AdminDeleteButton from './AdminDeleteButton';
+
+export default function Comment({ id, body }: { id: number; body: string }) {
+  // moved delete logic to AdminDeleteButton to avoid passing event handlers across server boundary
+
+  return (
+    <div className="p-2 border rounded bg-white dark:bg-gray-800">
+      <div className="text-sm">{body}</div>
+      <div className="mt-2 text-right">
+        <AdminDeleteButton type="comment" id={id} />
+      </div>
+    </div>
+  );
+}

--- a/front-end/components/DesktopSidebar.tsx
+++ b/front-end/components/DesktopSidebar.tsx
@@ -11,7 +11,8 @@ import {
 	Heart,
 	TrendingUp,
 	LogOut,
-	PlusCircle
+	PlusCircle,
+	Shield
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -73,6 +74,7 @@ export default function DesktopSidebar() {
 				<SidebarLink href="/likes" icon={<Heart />} label="Likes" active={isActive('/likes')} />
 				<SidebarLink href="/trending" icon={<TrendingUp />} label="Trending" active={isActive('/trending')} />
 				<SidebarLink href="/settings" icon={<Settings />} label="Settings" active={isActive('/settings')} />
+				<SidebarLink href="/admin" icon={<Shield />} label="Admin" active={isActive('/admin')} />
 			</nav>
 
 			{/* Create Post Button */}

--- a/front-end/components/MobileNav.tsx
+++ b/front-end/components/MobileNav.tsx
@@ -15,7 +15,8 @@ import {
 	TrendingUp,
 	LogOut,
 	Moon,
-	Sun
+	Sun,
+	Shield
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -164,6 +165,7 @@ export default function MobileNav() {
 
 					<div className="space-y-1 px-3">
 						<NavLink href="/settings" icon={<Settings className="w-5 h-5" />} label="Settings" onClick={closeMenu} active={isActive('/settings')} />
+						<NavLink href="/admin" icon={<Shield className="w-5 h-5" />} label="Admin" onClick={closeMenu} active={isActive('/admin')} />
 
 						{/* Dark Mode Toggle */}
 						<button

--- a/front-end/components/PostList.tsx
+++ b/front-end/components/PostList.tsx
@@ -1,4 +1,7 @@
 import axios from "axios";
+import AdminOnly from './AdminOnly';
+import Comment from './Comment';
+import AdminDeleteButton from './AdminDeleteButton';
 
 interface MockPostData {
 	userId: number;
@@ -14,9 +17,14 @@ export const PostList = async ({ id, isSelf }: { id: number, isSelf: boolean }) 
 		{posts.data.map(post => {
 			return <div key={post.id} className="m-2 shadow rounded-md bg-gray-100 pt-1 dark:bg-gray-800">
 				<div className="flex justify-end px-4">
-					<span className="text-xs">$</span>
+					<AdminDeleteButton type="post" id={post.id} />
 				</div>
 				<div className="px-4 mb-2 xl:my-6">{post.body}</div>
+				<div className="px-4 space-y-2">
+					{/* render a couple fake comments for demonstration */}
+					<Comment id={post.id * 100 + 1} body={`Comment A on post ${post.id}`} />
+					<Comment id={post.id * 100 + 2} body={`Comment B on post ${post.id}`} />
+				</div>
 				<div className="w-full border-t border-t-gray-200 dark:border-t-gray-900 p-2 flex text-xs">
 					<span className="w-1/3 flex justify-center">Comments</span>
 					<span className="w-0 border-l border-gray-200 dark:border-l-gray-900" ></span>


### PR DESCRIPTION
A lightweight admin dashboard + backend role support. Adds a Role enum in Prisma, allows creating users with a role from the service layer, and implements a naive, admin-only UI in the front-end with mock admin API routes for local testing.




WHAT IS LEFT TO IMPLEMENT

All backend routes related to admin moderations
All backend auth routes related to manage admin users